### PR TITLE
Updated ACL and added mime type

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ var storage = gcs({
 	bucket      : 'bucket-name', // Required : bucket name to upload
 	projectId      : 'dummy-project', // Required : Google project ID
 	keyFilename : '/path/to/keyfile.json', // Required : JSON credentials file for Google Cloud Storage
-	acl : 'publicread' // Optional : Defaults to private
+	acl : 'publicRead' // Optional : Defaults to projectPrivate. See options in the link below:
+	//https://cloud.google.com/storage/docs/access-control/lists
 });
 
 var gcsUpload = multer({ storage: storage });

--- a/index.js
+++ b/index.js
@@ -54,13 +54,13 @@ GCStorage.prototype._handleFile = function (req, file, cb) {
 	var self = this;
 	self.getDestination( req, file, function( err, destination ) {
 
-		if ( err ) {
-			return cb( err );
+		if (err) {
+			return cb(err);
 		}
 		
 		
 		self.getFilename( req, file, function( err, filename ) {
-			if ( err ) {
+			if (err) {
 				return cb( err );
 			}
 			
@@ -84,7 +84,7 @@ GCStorage.prototype._handleFile = function (req, file, cb) {
 			})
 			.on('finish', function(file) {
 			    return cb(null , {
-			    	path : 'https://' + self.options.bucket + '.storage.googleapis.com/' + filename ,
+			    	path : 'https://storage.googleapis.com/' + self.options.bucket + '/' + filename,
 			    	filename : filename
 			    });
 			});

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var gcloud = require('gcloud');
 var crypto = require( 'crypto' );
-var fs = require('fs')
+var fs = require('fs');
+var mime = require('mime-types');
+var path = require('path');
 
 function getFilename( req, file, cb ) {
 
@@ -55,13 +57,28 @@ GCStorage.prototype._handleFile = function (req, file, cb) {
 		if ( err ) {
 			return cb( err );
 		}
-
+		
+		
 		self.getFilename( req, file, function( err, filename ) {
 			if ( err ) {
 				return cb( err );
 			}
+			
+			//Set options for upload
+			var new_options = {
+				metadata: {}
+			}
+			
+			//Add predefined ACL
+			new_options.predefinedAcl = self.options.acl || 'projectPrivate';
+			
+			//Set mime type
+			var contentType = mime.contentType(path.basename(filename));
+			new_options.metadata.contentType = contentType;
+			
 			var gcFile = self.gcsBucket.file(filename);
-			file.stream.pipe(gcFile.createWriteStream({predefinedAcl : self.options.acl || 'private'}))
+			
+			file.stream.pipe(gcFile.createWriteStream(new_options))
 			.on('error', function(err) {
 				return cb(err);
 			})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multer-gcs",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Streaming multer storage engine for Google Cloud Storage",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
The ACL permissions in both README and index.js were wrong, so I fixed them based on https://cloud.google.com/storage/docs/access-control/lists.

I also added the ability to set a mime type, so that there is some information about the file.
